### PR TITLE
Mixed 1knode + 5knode Data

### DIFF
--- a/train/value/src/bin/chess.rs
+++ b/train/value/src/bin/chess.rs
@@ -53,7 +53,7 @@ fn main() {
 
     let settings = LocalSettings {
         threads: 4,
-        data_file_paths: vec!["data/chess/value5k.data"],
+        data_file_paths: vec!["data/chess/comb.data"],
         output_directory: "checkpoints",
     };
 


### PR DESCRIPTION
Elo   | 25.44 +- 12.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2490 W: 1075 L: 893 D: 522
Penta | [123, 176, 532, 224, 190]
https://chess.swehosting.se/test/6496/

Bench: 148671